### PR TITLE
Fix navigator dependency to prevent bundler error

### DIFF
--- a/app-estoque/App.js
+++ b/app-estoque/App.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createStackNavigator } from '@react-navigation/stack';
 import ListaProdutosScreen from './screens/ListaProdutosScreen';
 import AddProdutoScreen from './screens/AddProdutoScreen';
 import EditProdutoScreen from './screens/EditProdutoScreen';
 
-const Stack = createNativeStackNavigator();
+const Stack = createStackNavigator();
 
 export default function App() {
   return (

--- a/app-estoque/package.json
+++ b/app-estoque/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "@react-navigation/native": "^6.1.6",
-    "@react-navigation/native-stack": "^6.9.12",
+    "@react-navigation/stack": "^7.4.7",
     "expo": "^50.0.0",
     "react": "^18.2.0",
     "react-native": "^0.73.0"


### PR DESCRIPTION
## Summary
- use `@react-navigation/stack` instead of missing `native-stack`
- update dependencies accordingly

## Testing
- `npm test`
- `npm start -- --help` *(fails: expo: Permission denied)*

------
